### PR TITLE
Changed from deprecated device_state_attributes to extra_state_attributes

### DIFF
--- a/custom_components/miio_gateway/__init__.py
+++ b/custom_components/miio_gateway/__init__.py
@@ -448,7 +448,7 @@ class XiaomiGwDevice(RestoreEntity):
         return False
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         attrs = { ATTR_VOLTAGE: self._voltage, ATTR_LQI: self._lqi, ATTR_MODEL: self._model, ATTR_ALIVE: self._alive }
         return attrs
 

--- a/custom_components/miio_gateway/binary_sensor.py
+++ b/custom_components/miio_gateway/binary_sensor.py
@@ -105,8 +105,8 @@ class XiaomiGwBinarySensor(XiaomiGwDevice, BinarySensorEntity):
         return self._device_class
 
     @property
-    def device_state_attributes(self):
-        attrs = super().device_state_attributes
+    def extra_state_attributes(self):
+        attrs = super().extra_state_attributes
         if self._last_action is not None:
             attrs.update({ATTR_LAST_ACTION: self._last_action})
         return attrs


### PR DESCRIPTION
Changed from deprecated device_state_attributes to extra_state_attributes

Backwards compatibility for "device_state_attributes" deprecated in 2021.4
Warning added in 2021.12, will be removed in 2022.4